### PR TITLE
fix: update formatDateTime to use client timezone before sending sms

### DIFF
--- a/lib/actions/appointment.actions.ts
+++ b/lib/actions/appointment.actions.ts
@@ -120,6 +120,7 @@ export const sendSMSNotification = async (userId: string, content: string) => {
 export const updateAppointment = async ({
   appointmentId,
   userId,
+  timeZone,
   appointment,
   type,
 }: UpdateAppointmentParams) => {
@@ -134,7 +135,7 @@ export const updateAppointment = async ({
 
     if (!updatedAppointment) throw Error;
 
-    const smsMessage = `Greetings from CarePulse. ${type === "schedule" ? `Your appointment is confirmed for ${formatDateTime(appointment.schedule!).dateTime} with Dr. ${appointment.primaryPhysician}` : `We regret to inform that your appointment for ${formatDateTime(appointment.schedule!).dateTime} is cancelled. Reason:  ${appointment.cancellationReason}`}.`;
+    const smsMessage = `Greetings from CarePulse. ${type === "schedule" ? `Your appointment is confirmed for ${formatDateTime(appointment.schedule!, timeZone).dateTime} with Dr. ${appointment.primaryPhysician}` : `We regret to inform that your appointment for ${formatDateTime(appointment.schedule!, timeZone).dateTime} is cancelled. Reason:  ${appointment.cancellationReason}`}.`;
     await sendSMSNotification(userId, smsMessage);
 
     revalidatePath("/admin");

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,7 +10,7 @@ export const parseStringify = (value: any) => JSON.parse(JSON.stringify(value));
 export const convertFileToUrl = (file: File) => URL.createObjectURL(file);
 
 // FORMAT DATE TIME
-export const formatDateTime = (dateString: Date | string) => {
+export const formatDateTime = (dateString: Date | string, timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone) => {
   const dateTimeOptions: Intl.DateTimeFormatOptions = {
     // weekday: "short", // abbreviated weekday name (e.g., 'Mon')
     month: "short", // abbreviated month name (e.g., 'Oct')
@@ -18,7 +18,8 @@ export const formatDateTime = (dateString: Date | string) => {
     year: "numeric", // numeric year (e.g., '2023')
     hour: "numeric", // numeric hour (e.g., '8')
     minute: "numeric", // numeric minute (e.g., '30')
-    hour12: true, // use 12-hour clock (true) or 24-hour clock (false)
+    hour12: true, // use 12-hour clock (true) or 24-hour clock (false),
+    timeZone: timeZone, // use the provided timezone
   };
 
   const dateDayOptions: Intl.DateTimeFormatOptions = {
@@ -26,18 +27,21 @@ export const formatDateTime = (dateString: Date | string) => {
     year: "numeric", // numeric year (e.g., '2023')
     month: "2-digit", // abbreviated month name (e.g., 'Oct')
     day: "2-digit", // numeric day of the month (e.g., '25')
+    timeZone: timeZone, // use the provided timezone
   };
 
   const dateOptions: Intl.DateTimeFormatOptions = {
     month: "short", // abbreviated month name (e.g., 'Oct')
     year: "numeric", // numeric year (e.g., '2023')
     day: "numeric", // numeric day of the month (e.g., '25')
+    timeZone: timeZone, // use the provided timezone
   };
 
   const timeOptions: Intl.DateTimeFormatOptions = {
     hour: "numeric", // numeric hour (e.g., '8')
     minute: "numeric", // numeric minute (e.g., '30')
     hour12: true, // use 12-hour clock (true) or 24-hour clock (false)
+    timeZone: timeZone, // use the provided timezone
   };
 
   const formattedDateTime: string = new Date(dateString).toLocaleString(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,6 +51,7 @@ declare type CreateAppointmentParams = {
 declare type UpdateAppointmentParams = {
   appointmentId: string;
   userId: string;
+  timeZone: string;
   appointment: Appointment;
   type: string;
 };


### PR DESCRIPTION
Fix the timezone before sending the SMS. The timezone is different depending on the server, so we need to send the timezone from the client before sending the SMS. This way, the client will receive the SMS with the correct time.

Error reported :
https://discord.com/channels/710138849350647871/1264306368471629896