### PR TITLE
Fixed This warning " Warning: React Hook useCallback has a missing de…

### DIFF
--- a/components/FileUploader.tsx
+++ b/components/FileUploader.tsx
@@ -14,7 +14,8 @@ type FileUploaderProps = {
 export const FileUploader = ({ files, onChange }: FileUploaderProps) => {
   const onDrop = useCallback((acceptedFiles: File[]) => {
     onChange(acceptedFiles);
-  }, []);
+  },[onChange] // Add onChange to the dependency array
+  );
 
   const { getRootProps, getInputProps } = useDropzone({ onDrop });
 


### PR DESCRIPTION
…pendency: 'onChange'. Either include it or remove the dependency array. If 'onChange' changes too often, find the parent component that defines it and wrap that definition in useCallback ".tsx